### PR TITLE
Auth admin scenario

### DIFF
--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -10,6 +10,7 @@ Feature: Authenticate Dashboard User
   # with behave.
   
 Scenario: Existing User not logged in to any system
+  # a regular user with 'preservation-user' entitlement
   Given the user enters (or clicks) a URL for the Archivematica dashboard
   And Archivematica determines the user is not already logged in
   
@@ -23,6 +24,7 @@ Scenario: Existing User not logged in to any system
   And the Identity Provider redirects the user back to the dashboard
   And Archivematica validates the response from the Identity Provider
   And Archivematica determines the user authorities based on their role
+  And Archivematica determines the user is not able to access admin functions
   And the User is presented with the page of the URL they originally requested
   
 Scenario: Authenticated User attempts login without authority to use the preservation system
@@ -55,8 +57,22 @@ Scenario: Existing User logged in with Identity Provider
   And Archivematica determines the user authorities based on their role
   And the User is presented with the page of the URL they originally requested
 
+Scenario: Admin User not logged in
+  # admin user has 'preservation-admin' entitlement
+  Given the user enters (or clicks) a URL for the Archivematica dashboard
+  And Archivematica determines the user is not already logged in
+  
+  When Archivematica redirects the user to the Identity Provider
+  And the Identity Provider determines the user does not have an existing authenticated session
+  
+  Then the Identity Provider asks the user for their user name and password
+  And the user enters a user name and password that have admin entitlements
+  And the Identity Provider authenticates the (valid) user
+  And the Identity Provider redirects the user back to the dashboard
+  And Archivematica validates the response from the Identity Provider
+  And Archivematica determines the user is able to access admin functions
+  And the User is presented with the page of the URL they originally requested
+
 # Other Scenarios to be completed: 
 #       Existing user attempts to use expired session
-#       User signing in with non-admin account must not be able to access admin functions
-#       User signing in with admin account must be able to access admin functions 
 #       Authenticated by IdP with correct authorities (eduPersonEntitlement) but does not have AM user account yet


### PR DESCRIPTION
Taking the existing scenarios to be relevant to a user that does not have these permissions, I've added a scenario for an admin-based user. This is functionality that has been implemented.

Of the remaining "other scenarios" in this file:
* expired session - will depend on logout working, which we don't have yet
* not having an AM user account is kind of implied by these scenarios, if we take them to start from a clean install. Perhaps we should explicitly add that as a "Given" and then create a scenario for logging in as a pre-existing user. For manual testing, at least the pre-existence of the user will have to come from logging in and logging back out again. (so again, this is dependent on a working logout)

I think there is also a scenario where we log in to Dashboard, then go to Storage service and see that we're already logged in. Should we have a separate storage service feature file, with a similar set of scenarios? (and then the cross-site login goes into one or the other?)