### PR TITLE
update test cases for authenticate-dashboard-user

### DIFF
--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -67,21 +67,26 @@ Scenario: Preservation-User with existing IdP session logs in (Alice)
   And Alice is logged in with no admin privileges
   And Alice is presented with the default transfer page
 
-Scenario: Admin User not logged in
-  # admin user has 'preservation-admin' entitlement
-  Given the user enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines the user is not already logged in
+Scenario: Preservation-Admin logs in correct credentials (Bert)
+  Given Bert has an existing account with his identity provider 
+  And Bert has the entitlement "preservation-admin"
+  And Bert has an existing Archivematica user account 
+  And Bert is not already logged in to Archivematica
   
-  When Archivematica redirects the user to the Identity Provider
-  And the Identity Provider determines the user does not have an existing authenticated session
+  When Bert enters (or clicks) a URL for the Archivematica dashboard
+  And Archivematica determines Bert is not already logged in
+  And Archivematica redirects Bert to the Identity Provider
+  And the Identity Provider determines the Bert does not have an existing authenticated session
   
-  Then the Identity Provider asks the user for their user name and password
-  And the user enters a user name and password that have admin entitlements
-  And the Identity Provider authenticates the (valid) user
-  And the Identity Provider redirects the user back to the dashboard
+  Then the Identity Provider presents a login page
+  And Bert enters his user name and password
+  And the Identity Provider authenticates Bert
+  And the Identity Provider presents an Information Release consent page
+  And Bert selects the option "Ask me again at next login" and clicks "accept"
+  And the Identity Provider redirects Bert to Archivematica
   And Archivematica validates the response from the Identity Provider
-  And Archivematica determines the user is able to access admin functions
-  And the User is presented with the page of the URL they originally requested
+  And Bert is logged in with admin privileges
+  And Bert is presented with the default transfer page
 
 # Other Scenarios to be completed: 
 #       Existing user attempts to use expired session

--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -9,23 +9,27 @@ Feature: Authenticate Dashboard User
   # against a mock. The feature should pass a Gherkin linter but not execute testing
   # with behave.
   
-Scenario: Existing User not logged in to any system
-  # a regular user with 'preservation-user' entitlement
-  Given the user enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines the user is not already logged in
+Scenario: Preservation-User logs in with correct credentials (Alice)
+  Given Alice has an existing account with her identity provider 
+  And Alice has the entitlement "preservation-user"
+  And Alice has an existing Archivematica user account 
+  And Alice is not already logged in to Archivematica
   
-  When Archivematica redirects the user to the Identity Provider
-  And the Identity Provider determines the user does not have an existing authenticated session
+  When Alice enters (or clicks) a URL for the Archivematica dashboard
+  And Archivematica determines Alice is not already logged in
+  And Archivematica redirects Alice to the Identity Provider
+  And the Identity Provider determines the Alice does not have an existing authenticated session
   
-  Then the Identity Provider asks the user for their user name and password
-  And the user enters their user name and password
-  And the Identity Provider authenticates the (valid) user
-  And the Identity Provider redirects the user back to the dashboard
+  Then the Identity Provider presents an Information Release consent page
+  And Alice selects the option "Ask me again at next login" and clicks "accept"
+  And the Identity Provider presents a login page
+  And Alice enters her user name and password
+  And the Identity Provider authenticates Alice
+  And the Identity Provider redirects Alice to Archivematica
   And Archivematica validates the response from the Identity Provider
-  And Archivematica determines the user authorities based on their role
-  And Archivematica determines the user is not able to access admin functions
-  And the User is presented with the page of the URL they originally requested
-  
+  And Alice is logged in with no admin privileges
+  And Alice is presented with the default transfer page
+
 Scenario: Authenticated User attempts login without authority to use the preservation system
     # "authority" refers to the users eduPersonEntitlement of 'preservation-admin'or 'preservation-user'
   Given the user enters (or clicks) a URL for the Archivematica dashboard

--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -8,27 +8,32 @@ Feature: Authenticate Dashboard User
   # this feature specifies expected behaviour, but we won't automate testing  
   # against a mock. The feature should pass a Gherkin linter but not execute testing
   # with behave.
+
+Scenario: Preservation-User logs in with correct credentials
+  Given <user> has an existing account with her identity provider 
+    And <user> has the entitlement <entitlement>
+    And <user> has an existing Archivematica user account 
+    And <user> is not already logged in to Archivematica
   
-Scenario: Preservation-User logs in with correct credentials (Alice)
-  Given Alice has an existing account with her identity provider 
-  And Alice has the entitlement "preservation-user"
-  And Alice has an existing Archivematica user account 
-  And Alice is not already logged in to Archivematica
-  
-  When Alice enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines Alice is not already logged in
-  And Archivematica redirects Alice to the Identity Provider
-  And the Identity Provider determines the Alice does not have an existing authenticated session
+  When <user> enters (or clicks) a URL for the Archivematica dashboard
+    And Archivematica determines <user> is not already logged in
+    And Archivematica redirects <user> to the Identity Provider
+    And the Identity Provider determines the <user> does not have an existing authenticated session
   
   Then the Identity Provider presents a login page
-  And Alice enters her user name and password
-  And the Identity Provider authenticates Alice
-  And the Identity Provider presents an Information Release consent page
-  And Alice selects the option "Ask me again at next login" and clicks "accept"
-  And the Identity Provider redirects Alice to Archivematica
-  And Archivematica validates the response from the Identity Provider
-  And Alice is logged in with no admin privileges
-  And Alice is presented with the default transfer page
+    And <user> enters their user name <username> and password <password>
+    And the Identity Provider authenticates <user>
+    And the Identity Provider presents an Information Release consent page
+    And <user> selects the option "Ask me again at next login" and clicks "accept"
+    And the Identity Provider redirects <user> to Archivematica
+    And Archivematica validates the response from the Identity Provider
+    And <user> is logged in with <role> privileges
+    And <user> is presented with the default transfer page 
+    
+  Examples:
+    | user  | username | password | entitlement        | role       |
+    | Alice | aa       | aa12345  | preservation-user  | default    |
+    | Bert  | bb       | bb12345  | preservation-admin | admin      |
 
 Scenario: IdP user without credentials attempts login (Charlie)
   Given Charlie has an existing account with his identity provider 
@@ -66,27 +71,6 @@ Scenario: Preservation-User with existing IdP session logs in (Alice)
   And Archivematica validates the response from the Identity Provider
   And Alice is logged in with no admin privileges
   And Alice is presented with the default transfer page
-
-Scenario: Preservation-Admin logs in correct credentials (Bert)
-  Given Bert has an existing account with his identity provider 
-  And Bert has the entitlement "preservation-admin"
-  And Bert has an existing Archivematica user account 
-  And Bert is not already logged in to Archivematica
-  
-  When Bert enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines Bert is not already logged in
-  And Archivematica redirects Bert to the Identity Provider
-  And the Identity Provider determines the Bert does not have an existing authenticated session
-  
-  Then the Identity Provider presents a login page
-  And Bert enters his user name and password
-  And the Identity Provider authenticates Bert
-  And the Identity Provider presents an Information Release consent page
-  And Bert selects the option "Ask me again at next login" and clicks "accept"
-  And the Identity Provider redirects Bert to Archivematica
-  And Archivematica validates the response from the Identity Provider
-  And Bert is logged in with admin privileges
-  And Bert is presented with the default transfer page
 
 # Other Scenarios to be completed: 
 #       Existing user attempts to use expired session

--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -67,6 +67,8 @@ Scenario: Preservation-User with existing IdP session logs in (Alice)
   
   Then the Identity Provider presents an Information Release consent page
   And Alice selects the option "Ask me again at next login" and clicks "accept"
+      # these 2 steps will happen if user has previously chosen to ask for consent 
+      # at next login. If user chose to remember consent this step is skipped
   And the Identity Provider redirects Alice to Archivematica
   And Archivematica validates the response from the Identity Provider
   And Alice is logged in with no admin privileges

--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -20,31 +20,33 @@ Scenario: Preservation-User logs in with correct credentials (Alice)
   And Archivematica redirects Alice to the Identity Provider
   And the Identity Provider determines the Alice does not have an existing authenticated session
   
-  Then the Identity Provider presents an Information Release consent page
-  And Alice selects the option "Ask me again at next login" and clicks "accept"
-  And the Identity Provider presents a login page
+  Then the Identity Provider presents a login page
   And Alice enters her user name and password
   And the Identity Provider authenticates Alice
+  And the Identity Provider presents an Information Release consent page
+  And Alice selects the option "Ask me again at next login" and clicks "accept"
   And the Identity Provider redirects Alice to Archivematica
   And Archivematica validates the response from the Identity Provider
   And Alice is logged in with no admin privileges
   And Alice is presented with the default transfer page
 
-Scenario: Authenticated User attempts login without authority to use the preservation system
-    # "authority" refers to the users eduPersonEntitlement of 'preservation-admin'or 'preservation-user'
-  Given the user enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines the user is not already logged in
+Scenario: IdP user without credentials attempts login (Charlie)
+  Given Charlie has an existing account with his identity provider 
+  And Charlie does not have "preservation-user" or "preservation-admin" entitlements
+  And Charlie is not already logged in to his identity provider
   
-  When Archivematica redirects the user to the Identity Provider
-  And the Identity Provider determines the user does not have an existing authenticated session
+  When Charlie enters (or clicks) a URL for the Archivematica dashboard
+  And Archivematica determines Charlie is not already logged in
+  And Archivematica redirects Charlie to the Identity Provider
+  And the Identity Provider determines Charlie does not have an existing authenticated session
   
-  Then the Identity Provider asks the user for their user name and password
-  And the user enters their user name and password
-  And the Identity Provider authenticates the (valid) user
+  Then the Identity Provider presents a login page
+  And Charlie enters his user name and password
+  And the Identity Provider authenticates Charlie
+  And the Identity Provider presents an Information Release consent page
+  And Charlie selects the option "Ask me again at next login" and clicks "accept"
   And the Identity Provider redirects the user back to the dashboard
-  And Archivematica validates the response from the Identity Provider
-  And Archivematica determines the user does not have authority to access the resource based on their role
-  And the User is presented with an "Access Denied" page informing them to contact their administrator 
+  And the Charlie is presented with an "Access Denied" page informing them to contact their administrator 
   
 Scenario: Existing User logged in with Identity Provider
   Given the user enters (or clicks) a URL for the Archivematica dashboard

--- a/features/Jisc/authenticate-dashboard-user.feature
+++ b/features/Jisc/authenticate-dashboard-user.feature
@@ -48,17 +48,24 @@ Scenario: IdP user without credentials attempts login (Charlie)
   And the Identity Provider redirects the user back to the dashboard
   And the Charlie is presented with an "Access Denied" page informing them to contact their administrator 
   
-Scenario: Existing User logged in with Identity Provider
-  Given the user enters (or clicks) a URL for the Archivematica dashboard
-  And Archivematica determines the user is not already logged in
+Scenario: Preservation-User with existing IdP session logs in (Alice)
+  Given Alice has an existing account with her identity provider 
+  And Alice has the entitlement "preservation-user"
+  And Alice has an existing Archivematica user account 
+  And Alice is not already logged in to Archivematic
+  And Alice IS logged in with her Identity Provider
   
-  When Archivematica redirects the user to the Identity Provider
-  And the Identity Provider determines the user already has an existing authenticated session
+  When Alice enters (or clicks) a URL for the Archivematica dashboard
+  And Archivematica determines Alice is not already logged in
+  And Archivematica redirects the user to the Identity Provider
+  And the Identity Provider determines Alice already has an existing authenticated session
   
-  Then the Identity Provider redirects the user back to the dashboard
+  Then the Identity Provider presents an Information Release consent page
+  And Alice selects the option "Ask me again at next login" and clicks "accept"
+  And the Identity Provider redirects Alice to Archivematica
   And Archivematica validates the response from the Identity Provider
-  And Archivematica determines the user authorities based on their role
-  And the User is presented with the page of the URL they originally requested
+  And Alice is logged in with no admin privileges
+  And Alice is presented with the default transfer page
 
 Scenario: Admin User not logged in
   # admin user has 'preservation-admin' entitlement


### PR DESCRIPTION
Replace 'user' with "Alice", "Bert" and "Charlie" to map to test users accounts set up (and improve readability).
Added 'given' steps to better show user set up - e.g. with specific entitlements, and to clarify the difference between and IdP user account, and an Archivematica user account. 
Add step for the information release page with IdP.